### PR TITLE
Updated to dynamic Github Pages redirects

### DIFF
--- a/dspace/.htaccess
+++ b/dspace/.htaccess
@@ -1,11 +1,15 @@
 RewriteEngine On
 
-RewriteRule ^v0\.8/context\.json$ https://github.com/International-Data-Spaces-Association/ids-specification/raw/main/common/schema/context.json [R=302,L,QSA]
+# Redirect main JSON-LD context
+RewriteRule ^(head|v[0-9][.][0-9])/context.json https://international-data-spaces-association.github.io/ids-specification/$1/common/schema/context.json [R=302,L,QSA]
 
-RewriteRule ^v0\.8/contract-schema\.json$ https://raw.githubusercontent.com/International-Data-Spaces-Association/ids-specification/main/negotiation/message/schema/contract-schema.json [R=302,L,QSA]
+# Redirect JSON Schemas
+RewriteRule ^(head|v[0-9][.][0-9])/(catalog|negotiation|transfer)/([\w.-]+schema.json) https://international-data-spaces-association.github.io/ids-specification/$1/$2/message/schema/$3 [R=302,L,QSA]
+RewriteRule ^(head|v[0-9][.][0-9])/common/([\w.-]+schema.json) https://international-data-spaces-association.github.io/ids-specification/$1/common/schema/$2 [R=302,L,QSA]
 
-RewriteRule ^v0\.8/dataset-schema\.json$ https://raw.githubusercontent.com/International-Data-Spaces-Association/ids-specification/main/catalog/message/schema/dataset-schema.json [R=302,L,QSA]
+# Redirect SHACL Shapes
+RewriteRule ^(head|v[0-9][.][0-9])/(catalog|negotiation|transfer)/([\w.-]+shapes?.ttl) https://international-data-spaces-association.github.io/ids-specification/$1/$2/message/shape/$3 [R=302,L,QSA]
+RewriteRule ^(head|v[0-9][.][0-9])/common/([\w.-]+shapes?.ttl) https://international-data-spaces-association.github.io/ids-specification/$1/common/shape/$2 [R=302,L,QSA]
 
-RewriteRule ^v0\.8/catalog-schema\.json$ https://raw.githubusercontent.com/International-Data-Spaces-Association/ids-specification/main/catalog/message/schema/catalog-schema.json [R=302,L,QSA]
-
+# Redirect to repository
 RewriteRule ^.*$ https://github.com/International-Data-Spaces-Association/ids-specification [R=302,L,QSA]

--- a/dspace/README.md
+++ b/dspace/README.md
@@ -12,10 +12,14 @@ Find more information at [https://internationaldataspaces.org/](https://internat
 
 
 ### Redirections:
-* https://w3id.org/dspace/v0.8/context.json --> https://github.com/International-Data-Spaces-Association/ids-specification/raw/main/common/schema/context.json
-* https://w3id.org/dspace/v0.8/contract-schema.json --> https://raw.githubusercontent.com/International-Data-Spaces-Association/ids-specification/main/negotiation/message/schema/contract-schema.json
-* https://w3id.org/dspace/v0.8/dataset-schema.json --> https://raw.githubusercontent.com/International-Data-Spaces-Association/ids-specification/main/catalog/message/schema/dataset-schema.json
-* https://w3id.org/dspace/v0.8/dataset-schema.json --> https://raw.githubusercontent.com/International-Data-Spaces-Association/ids-specification/main/catalog/message/schema/dataset-schema.json
+* https://w3id.org/dspace/v0.8/context.json --> https://international-data-spaces-association.github.io/ids-specification/v0.8/common/schema/context.json
+* https://w3id.org/dspace/v0.8/catalog/catalog-schema.json --> https://international-data-spaces-association.github.io/ids-specification/v0.8/catalog/message/schema/catalog-schema.json
+* https://w3id.org/dspace/v0.8/catalog/dataset-schema.json --> https://international-data-spaces-association.github.io/ids-specification/v0.8/catalog/message/schema/dataset-schema.json
+* https://w3id.org/dspace/v0.8/negotiation/contract-schema.json --> https://international-data-spaces-association.github.io/ids-specification/v0.8/negotiation/message/schema/contract-schema.json
+* https://w3id.org/dspace/v0.8/catalog/dcat-shapes.ttl --> https://international-data-spaces-association.github.io/ids-specification/v0.8/catalog/message/shape/dcat-shapes.ttl
+* https://w3id.org/dspace/v0.8/common/definitions.schema.json --> https://international-data-spaces-association.github.io/ids-specification/v0.8/common/schema/definitions.schema.json
+* https://w3id.org/dspace/v0.8/common/odrl-shapes.ttl --> https://international-data-spaces-association.github.io/ids-specification/v0.8/common/shape/odrl-shapes.ttl
+* https://w3id.org/dspace/v0.8/common/message-shape.ttl --> https://international-data-spaces-association.github.io/ids-specification/v0.8/common/shape/message-shape.ttl
 * https://w3id.org/dspace* --> https://github.com/International-Data-Spaces-Association/ids-specification/
 
 ## Contact


### PR DESCRIPTION
This pull request updates the redirects so that they point towards the Github Pages instead of the Github raw links.

I also made the expressions a bit more dynamic, so that they include all the schemas and shapes without having to create separate entries for all of them.

Two open points for which I made a choice but might require more discussion:
* For the versions I now use a vX.X variant in the regular expressions, which results in the fact for instance a v1 release must be v1.0. @ssteinbuss is this assumption still correct?
* The w3id links now must contain `catalog`, `negotiation`, `transfer`, or `common`, but do not require `message/schema` or `message/shape`. This gives a bit of structure, but omits the full folder structure. The question is whether this is desirable? @sebbader-sap what's your opinion on this? 